### PR TITLE
Renamed neurosciencegraph/morphology/ReconstructedCellFormatConversion

### DIFF
--- a/modules/morphology/src/main/resources/schemas/neurosciencegraph/morphology/morphologyformatconversion/v0.1.0.json
+++ b/modules/morphology/src/main/resources/schemas/neurosciencegraph/morphology/morphologyformatconversion/v0.1.0.json
@@ -2,7 +2,7 @@
   "@context": [
     "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
     {
-      "this": "{{base}}/schemas/neurosciencegraph/morphology/reconstructedcellformatconversion/v0.1.0/shapes/"
+      "this": "{{base}}/schemas/neurosciencegraph/morphology/morphologyformatconversion/v0.1.0/shapes/"
     }
   ],
   "@type": "nxv:Schema",


### PR DESCRIPTION
Renamed to neurosciencegraph/morphology/morphologyformatconversion