### PR TITLE
Add a cut plane schema

### DIFF
--- a/modules/morphology/src/main/resources/schemas/neurosciencegraph/morphology/cutplane/v0.1.0.json
+++ b/modules/morphology/src/main/resources/schemas/neurosciencegraph/morphology/cutplane/v0.1.0.json
@@ -1,0 +1,42 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "this": "{{base}}/schemas/neurosciencegraph/morphology/cutplane/v0.1.0/shapes/"
+    }
+  ],
+  "@type": "nxv:Schema",
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/entity/v1.0.0"
+  ],
+  "shapes": [
+    {
+      "@id": "this:CutPlaneShape",
+      "@type": "sh:NodeShape",
+      "label": "CutPlane shape",
+      "targetClass": "nsg:CutPlane",
+      "nodekind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/entity/v1.0.0/EntityShape"
+        },
+        {
+          "property": [
+            {
+              "path": "schema:distribution",
+              "name": "Cut plane file (s)",
+              "description": "Link to the cut plane file.",
+              "node": "{{base}}/schemas/nexus/core/distribution/v0.1.0",
+              "maxCount": 1
+            },
+              {
+                  "class": "prov:Entity",
+                  "description": "The experimental morphology from which the features have been extracted.",
+                  "path": "nsg:morphology"
+              }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The cut plane is a JSON file that describes information about the plane
of cut of a particular experimental morphology.

I'd also like to add a contraint such that every experimental morphology maps
to maximum one cut plane instance but I don't know how to set that.