### PR TITLE
Initialize Literature Annotation domain model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,12 +100,23 @@ lazy val simulation = project
     moduleName := "nsg-simulation-schemas"
   )
 
+lazy val literatureannotation = project
+  .in(file("modules/literatureannotation"))
+  .enablePlugins(WorkbenchPlugin)
+  .disablePlugins(ScapegoatSbtPlugin, DocumentationPlugin)
+  .dependsOn(core)
+  .settings(common)
+  .settings(
+    name       := "nsg-literatureannotation-schemas",
+    moduleName := "nsg-literatureannotation-schemas"
+  )
+
 
 lazy val root = project
   .in(file("."))
   .settings(name := "nsg-schemas", moduleName := "nsg-schemas")
   .settings(common, noPublish)
-  .aggregate(core, experiment, atlas, morphology, electrophysiology, simulation, nexusschema,nsgcommons)
+  .aggregate(core, experiment, atlas, morphology, electrophysiology, simulation, nexusschema, nsgcommons, literatureannotation)
 
 lazy val common = Seq(
   scalacOptions in (Compile, console) ~= (_ filterNot (_ == "-Xfatal-warnings")),

--- a/modules/commons/src/main/resources/schemas/neurosciencegraph/commons/annotation/v0.1.0.json
+++ b/modules/commons/src/main/resources/schemas/neurosciencegraph/commons/annotation/v0.1.0.json
@@ -1,0 +1,201 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/entity/v1.0.0",
+    "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "AnnotationShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/entity/v1.0.0/shapes/EntityShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:contribution",
+              "name": "Contribution",
+              "description": "Information about the agent involved in the creation of this Annotation.",
+              "node": "ContributionShape",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:hasTarget",
+              "name": "Target",
+              "description": "The relationship between an Annotation and its Target.",
+              "node": "TargetShape",
+              "minCount": 1
+            },
+            {
+              "path": "nsg:hasBody",
+              "name": "Body",
+              "description": "The relationship between an Annotation and its Body.",
+              "node": "BodyShape"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "TargetShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI"
+    },
+    {
+      "@id": "SelectorTargetShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "TargetShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:hasSource",
+              "name": "Source",
+              "description": "The relationship between a Specific Resource and the resource that it is a more specific representation of.",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:hasSelector",
+              "name": "Selector",
+              "description": "The relationship between a Specific Resource and a Selector.",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/SelectorShape"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "TextPositionTargetShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "SelectorTargetShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:hasSelector",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/TextPositionSelectorShape",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "FigureTargetShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "SelectorTargetShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:hasSelector",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/FigureSelectorShape",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "EquationTargetShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "SelectorTargetShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:hasSelector",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/EquationSelectorShape",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "TableTargetShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "SelectorTargetShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:hasSelector",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/TableSelectorShape",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "AreaTargetShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "SelectorTargetShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:hasSelector",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/AreaSelectorShape",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "BodyShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI"
+    },
+    {
+      "@id": "ContributionShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "property": [
+        {
+          "path": "prov:agent",
+          "name": "Agent",
+          "nodeKind": "sh:IRI",
+          "class": "prov:Agent",
+          "minCount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/modules/commons/src/main/resources/schemas/neurosciencegraph/commons/parameter/v0.1.0.json
+++ b/modules/commons/src/main/resources/schemas/neurosciencegraph/commons/parameter/v0.1.0.json
@@ -1,0 +1,20 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/commons/parameter/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/entity/v1.0.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "ParameterShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/entity/v1.0.0/shapes/EntityShape"
+    }
+  ]
+}

--- a/modules/commons/src/main/resources/schemas/neurosciencegraph/commons/selectors/v0.1.0.json
+++ b/modules/commons/src/main/resources/schemas/neurosciencegraph/commons/selectors/v0.1.0.json
@@ -1,0 +1,174 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/"
+    }
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "SelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "property": [
+        {
+          "path": "rdf:type",
+          "name": "Selector type",
+          "description": "The class of the Selector.",
+          "minCount": 1,
+          "maxCount": 1
+        }
+      ]
+    },
+    {
+      "@id": "TextPositionSelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "class": "nsg:TextPositionSelector",
+      "and": [
+        {
+          "node": "SelectorShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:start",
+              "name": "Start offset",
+              "description": "The starting position of the segment of text. The first character in the full text is character position 0, and the character is included within the segment.",
+              "datatype": "xsd:integer",
+              "minInclusive": 0,
+              "lessThan": "nsg:end",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:end",
+              "name": "End offset",
+              "description": "The end position of the segment of text. The character is not included within the segment.",
+              "datatype": "xsd:integer",
+              "minInclusive": 0,
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:text",
+              "name": "Text",
+              "description": "The segment of text.",
+              "datatype": "xsd:string",
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "IndexSelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "SelectorShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:index",
+              "name": "Index",
+              "description": "The index in the document, verbatim (e.g. '1', '2.a', 'III').",
+              "datatype": "xsd:string",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "FigureSelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "class": "nsg:FigureSelector",
+      "node": "IndexSelectorShape"
+    },
+    {
+      "@id": "EquationSelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "class": "nsg:EquationSelector",
+      "node": "IndexSelectorShape"
+    },
+    {
+      "@id": "TableSelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "class": "nsg:TableSelector",
+      "and": [
+        {
+          "node": "IndexSelectorShape"
+        },
+        {
+          "property": [
+            {
+              "path": "row",
+              "name": "Row index",
+              "description": "The index(es) in the table of the row(s) (e.g. '1', '1, 3')."
+            },
+            {
+              "path": "column",
+              "name": "Column index",
+              "description": "The index(es) in the table of the columns(s) (e.g. '1', '1, 3')."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "FragmentSelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "SelectorShape"
+        },
+        {
+          "property": [
+            {
+              "path": "rdf:value",
+              "name": "Fragment value",
+              "description": "The contents of the fragment component of an IRI that describes the Segment.",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "dcterms:conformsTo",
+              "name": "Fragment specification",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "AreaSelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "class": "nsg:AreaSelector",
+      "and": [
+        {
+          "node": "FragmentSelectorShape"
+        },
+        {
+          "property": [
+            {
+              "path": "dcterms:conformsTo",
+              "comment": "Used format is page=<pagenum>&viewrect=<left>,<top>,<wd>,<ht>. <left>, and <top> are measured from the top left corner of the page.",
+              "hasValue": "http://tools.ietf.org/rfc/rfc3778"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/commons/src/main/resources/schemas/neurosciencegraph/commons/variables/v0.1.0.json
+++ b/modules/commons/src/main/resources/schemas/neurosciencegraph/commons/variables/v0.1.0.json
@@ -1,0 +1,136 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/"
+    }
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "AlgebraicValueShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "property": [
+        {
+          "path": "schema:unitCode",
+          "name": "Unit code",
+          "datatype": "xsd:string",
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "nsg:statistic",
+          "name": "Statistic",
+          "description": "The name of the statistic describing the sample.",
+          "datatype": "xsd:string",
+          "maxCount": 1
+        }
+      ]
+    },
+    {
+      "@id": "ValueShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "AlgebraicValueShape"
+        },
+        {
+          "property": [
+            {
+              "path": "schema:value",
+              "name": "Value",
+              "datatype": "xsd:float",
+              "minCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "VariableShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "property": [
+        {
+          "path": "nsg:quantityType",
+          "name": "Quantity type",
+          "description": "The type of the measured quantity represented by the variable.",
+          "minCount": 1,
+          "maxCount": 1
+        }
+      ]
+    },
+    {
+      "@id": "NumericalVariableShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "VariableShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:series",
+              "name": "Series",
+              "description": "The numerical value(s) taken by the variable",
+              "node": "ValueShape"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "SimpleNumericalVariableShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "NumericalVariableShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:series",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "CompoundNumericalVariableShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "NumericalVariableShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:series",
+              "minCount": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "AlgebraicVariableShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "VariableShape"
+        },
+        {
+          "node": "AlgebraicValueShape"
+        }
+      ]
+    }
+  ]
+}

--- a/modules/core/src/main/resources/schemas/neurosciencegraph/core/annotation/v0.1.0.json
+++ b/modules/core/src/main/resources/schemas/neurosciencegraph/core/annotation/v0.1.0.json
@@ -1,0 +1,62 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/core/annotation/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "AnnotationShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:Annotation",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/AnnotationShape"
+    },
+    {
+      "@id": "SelectorTargetShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:SelectorTargetShape",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/SelectorTarget"
+    },
+    {
+      "@id": "TextPositionTargetShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:TextPositionTarget",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/TextPositionTargetShape"
+    },
+    {
+      "@id": "FigureTargetShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:FigureTarget",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/FigureTargetShape"
+    },
+    {
+      "@id": "EquationTargetShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:EquationTarget",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/EquationTargetShape"
+    },
+    {
+      "@id": "TableTargetShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:TableTarget",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/TableTargetShape"
+    },
+    {
+      "@id": "AreaTargetShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:AreaTarget",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/AreaTargetShape"
+    },
+    {
+      "@id": "ContributionShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:Contribution",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/ContributionShape"
+    }
+  ]
+}

--- a/modules/core/src/main/resources/schemas/neurosciencegraph/core/selectors/v0.1.0.json
+++ b/modules/core/src/main/resources/schemas/neurosciencegraph/core/selectors/v0.1.0.json
@@ -1,0 +1,63 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/core/selectors/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "SelectorShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:Selector",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/SelectorShape"
+    },
+    {
+      "@id": "TextPositionSelectorShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:TextPositionSelector",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/TextPositionSelectorShape"
+    },
+    {
+      "@id": "IndexSelectorShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "targetClass": "nsg:IndexSelector",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/IndexSelectorShape"
+    },
+    {
+      "@id": "FigureSelectorShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:FigureSelector",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/FigureSelectorShape"
+    },
+    {
+      "@id": "EquationSelectorShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:EquationSelector",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/EquationSelectorShape"
+    },
+    {
+      "@id": "TableSelectorShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:TableSelector",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/TableSelectorShape"
+    },
+    {
+      "@id": "FragmentSelectorShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:FragmentSelector",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/FragmentSelectorShape"
+    },
+    {
+      "@id": "AreaSelectorShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:AreaSelector",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/selectors/v0.1.0/shapes/AreaSelectorShape"
+    }
+  ]
+}

--- a/modules/core/src/main/resources/schemas/neurosciencegraph/core/variables/v0.1.0.json
+++ b/modules/core/src/main/resources/schemas/neurosciencegraph/core/variables/v0.1.0.json
@@ -1,0 +1,56 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/core/variables/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "AlgebraicValueShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:AlgebraicValue",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/AlgebraicValueShape"
+    },
+    {
+      "@id": "ValueShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:Value",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/ValueShape"
+    },
+    {
+      "@id": "VariableShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:Variable",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/VariableShape"
+    },
+    {
+      "@id": "NumericalVariableShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:NumericalVariable",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/NumericalVariableShape"
+    },
+    {
+      "@id": "SimpleNumericalVariableShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:SimpleNumericalVariable",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/SimpleNumericalVariableShape"
+    },
+    {
+      "@id": "CompoundNumericalVariableShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:CompoundNumericalVariable",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/CompoundNumericalVariableShape"
+    },
+    {
+      "@id": "AlgebraicVariableShape",
+      "@type": "sh:NodeShape",
+      "targetClass": "nsg:AlgebraicVariable",
+      "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/AlgebraicVariableShape"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/main/resources/schemas/neurosciencegraph/literatureannotation/functionparameter/v0.1.0.json
+++ b/modules/literatureannotation/src/main/resources/schemas/neurosciencegraph/literatureannotation/functionparameter/v0.1.0.json
@@ -1,0 +1,53 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/literatureannotation/functionparameter/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/parameter/v0.1.0",
+    "{{base}}/schemas/neurosciencegraph/core/variables/v0.1.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "FunctionParameterShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "targetClass": "nsg:FunctionParameter",
+      "comment": "Parameter shape for a functional relationship between independent and dependent variables.",
+      "and": [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/parameter/v0.1.0/shapes/ParameterShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:dependentVariable",
+              "name": "Dependent variable",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/AlgebraicVariableShape",
+              "class": "nsg:AlgebraicVariable",
+              "minCount": 1
+            },
+            {
+              "path": "nsg:independentVariable",
+              "name": "Independent variable",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/AlgebraicVariableShape",
+              "class": "nsg:AlgebraicVariable",
+              "minCount": 1
+            },
+            {
+              "path": "nsg:equation",
+              "name": "Equation",
+              "description": "The functional relationship described with the variable type labels and the Python mathematical operators.",
+              "datatype": "xsd:string",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/literatureannotation/src/main/resources/schemas/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0.json
+++ b/modules/literatureannotation/src/main/resources/schemas/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0.json
@@ -1,0 +1,61 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/parameter/v0.1.0",
+    "{{base}}/schemas/neurosciencegraph/core/variables/v0.1.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "NumericalTraceParameterShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "targetClass": "nsg:NumericalTraceParameter",
+      "comment": "Parameter shape for the values of (an) independent variable(s) associated with the values of (a) dependent variable(s).",
+      "and": [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/parameter/v0.1.0/shapes/ParameterShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:dependentVariable",
+              "name": "Dependent variable",
+              "sh:xone": [
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/SimpleNumericalVariableShape",
+                  "class": "nsg:SimpleNumericalVariable"
+                },
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/CompoundNumericalVariableShape",
+                  "class": "nsg:CompoundNumericalVariable"
+                }
+              ],
+              "minCount": 1
+            },
+            {
+              "path": "nsg:independentVariable",
+              "name": "Independent variable",
+              "sh:xone": [
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/SimpleNumericalVariableShape",
+                  "class": "nsg:SimpleNumericalVariable"
+                },
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/CompoundNumericalVariableShape",
+                  "class": "nsg:CompoundNumericalVariable"
+                }
+              ],
+              "minCount": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/literatureannotation/src/main/resources/schemas/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0.json
+++ b/modules/literatureannotation/src/main/resources/schemas/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0.json
@@ -1,0 +1,61 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/core/annotation/v0.1.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "ParameterAnnotationShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "targetClass": "nsg:ParameterAnnotation",
+      "and": [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/AnnotationShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:hasTarget",
+              "sh:xone": [
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/TextPositionTargetShape",
+                  "class": "nsg:TextPositionTarget"
+                },
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/FigureTargetShape",
+                  "class": "nsg:FigureTarget"
+                },
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/EquationTargetShape",
+                  "class": "nsg:EquationTarget"
+                },
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/TableTargetShape",
+                  "class": "nsg:TableTarget"
+                },
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/annotation/v0.1.0/shapes/AreaTargetShape",
+                  "class": "nsg:AreaTarget"
+                }
+              ],
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:hasBody",
+              "nodeKind": "sh:IRI",
+              "class": "nsg:Parameter",
+              "minCount": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/literatureannotation/src/main/resources/schemas/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0.json
+++ b/modules/literatureannotation/src/main/resources/schemas/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0.json
@@ -1,0 +1,47 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "@base": "{{base}}/schemas/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/shapes/"
+    }
+  ],
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/parameter/v0.1.0",
+    "{{base}}/schemas/neurosciencegraph/core/variables/v0.1.0"
+  ],
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "PointValueParameterShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "targetClass": "nsg:PointValueParameter",
+      "comment": "Parameter shape for the value(s) of an unidimensional variable (i.e., not establishing a relationship between a dependant and an independent variable).",
+      "and": [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/parameter/v0.1.0/shapes/ParameterShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:dependentVariable",
+              "name": "Dependent variable",
+              "sh:xone": [
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/SimpleNumericalVariableShape",
+                  "class": "nsg:SimpleNumericalVariable"
+                },
+                {
+                  "node": "{{base}}/schemas/neurosciencegraph/commons/variables/v0.1.0/shapes/CompoundNumericalVariableShape",
+                  "class": "nsg:CompoundNumericalVariable"
+                }
+              ],
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/functionparameter/v0.1.0/auto-all-fields.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/functionparameter/v0.1.0/auto-all-fields.json
@@ -1,0 +1,41 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:FunctionParameter",
+  "name": "p-prop_inact_ion_curr-71233092",
+  "providerId": "71233092-eb80-11e5-a9b7-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:AlgebraicVariable",
+    "quantityType": "nsg:BBP-050002",
+    "unitCode": "dimensionless"
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:AlgebraicVariable",
+      "quantityType": "nsg:BBP-010001",
+      "unitCode": "mV"
+    }
+  ],
+  "equation": "prop_inact_ion_curr = 1/(1+exp((potential_membrane - mid_amp_inact)/slope_factor_inact))",
+  "equationParameters": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/762f45f0-eade-11e5-94e2-64006a4c56ef",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/7f3542e0-eb82-11e5-ac32-64006a4c56ef",
+      "@type": "nsg:Parameter"
+    }
+  ],
+  "requiredTag": [
+    {
+      "rootId": "nifext_8054",
+      "id": "NIFMOL:nifext_8054",
+      "label": "Transmembrane ionic current"
+    },
+    {
+      "rootId": "sao1813327414",
+      "id": "NIFCELL:sao1813327414",
+      "label": "Cell"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/functionparameter/v0.1.0/auto-min-fields.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/functionparameter/v0.1.0/auto-min-fields.json
@@ -1,0 +1,19 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:FunctionParameter",
+  "name": "p-prop_inact_ion_curr-71233092",
+  "providerId": "71233092-eb80-11e5-a9b7-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:AlgebraicVariable",
+    "quantityType": "nsg:BBP-050002",
+    "unitCode": "dimensionless"
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:AlgebraicVariable",
+      "quantityType": "nsg:BBP-010001",
+      "unitCode": "mV"
+    }
+  ],
+  "equation": "prop_inact_ion_curr = 1/(1+exp((potential_membrane - mid_amp_inact)/slope_factor_inact))"
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/all-fields-compound-compound-ignored.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/all-fields-compound-compound-ignored.json
@@ -1,0 +1,5 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "comment": "No data on 24.09.18"
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/all-fields-simple-compound-ignored.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/all-fields-simple-compound-ignored.json
@@ -1,0 +1,5 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "comment": "No data on 24.09.18"
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-all-fields-compound-simple.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-all-fields-compound-simple.json
@@ -1,0 +1,56 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "name": "p-spine_number_per_cell-db0e39fe",
+  "providerId": "db0e39fe-9a9c-11e6-974a-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "quantityType": "nsg:BBP-121008",
+    "series": [
+      {
+        "statistic": "mean",
+        "unitCode": "dimensionless",
+        "value": [
+          109.6,
+          81.6
+        ]
+      },
+      {
+        "statistic": "sem",
+        "unitCode": "dimensionless",
+        "value": [
+          27.1,
+          15.1
+        ]
+      },
+      {
+        "statistic": "N",
+        "unitCode": "dimensionless",
+        "value": [
+          15.0,
+          16.0
+        ]
+      }
+    ]
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:SimpleNumericalVariable",
+      "quantityType": "nsg:BBP-002001",
+      "series": {
+        "unitCode": "day",
+        "value": [
+          14.0,
+          21.0
+        ]
+      }
+    }
+  ],
+  "requiredTag": [
+    {
+      "rootId": "NIFCELL:sao1813327414",
+      "id": "NIFCELL:nifext_46",
+      "label": "Thalamus interneuron small"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-all-fields-simple-simple.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-all-fields-simple-simple.json
@@ -1,0 +1,51 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "name": "p-neuron_density-0ebdc338",
+  "providerId": "0ebdc338-6d38-11e6-b432-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-131001",
+    "series": {
+      "statistic": "mean",
+      "unitCode": "mm^-3",
+      "value": [
+        278146.0,
+        170264.0,
+        88874.4,
+        51258.8,
+        50132.7,
+        27815.8
+      ]
+    }
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:SimpleNumericalVariable",
+      "quantityType": "nsg:BBP-002001",
+      "series": {
+        "unitCode": "day",
+        "value": [
+          0.0,
+          3.0,
+          6.0,
+          12.0,
+          21.0,
+          30.0
+        ]
+      }
+    }
+  ],
+  "requiredTag": [
+    {
+      "rootId": "NIFGA:birnlex_1167",
+      "id": "NIFGA:birnlex_1116",
+      "label": "Ventral posterior nucleus"
+    },
+    {
+      "rootId": "NIFCELL:sao1813327414",
+      "id": "NIFCELL:nlx_cell_20081203",
+      "label": "Thalamus relay cell"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-min-fields-compound-simple.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-min-fields-compound-simple.json
@@ -1,0 +1,49 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "name": "p-spine_number_per_cell-db0e39fe",
+  "providerId": "db0e39fe-9a9c-11e6-974a-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "quantityType": "nsg:BBP-121008",
+    "series": [
+      {
+        "statistic": "mean",
+        "unitCode": "dimensionless",
+        "value": [
+          109.6,
+          81.6
+        ]
+      },
+      {
+        "statistic": "sem",
+        "unitCode": "dimensionless",
+        "value": [
+          27.1,
+          15.1
+        ]
+      },
+      {
+        "statistic": "N",
+        "unitCode": "dimensionless",
+        "value": [
+          15.0,
+          16.0
+        ]
+      }
+    ]
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:SimpleNumericalVariable",
+      "quantityType": "nsg:BBP-002001",
+      "series": {
+        "unitCode": "day",
+        "value": [
+          14.0,
+          21.0
+        ]
+      }
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-min-fields-simple-simple.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-min-fields-simple-simple.json
@@ -1,0 +1,39 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "name": "p-neuron_density-0ebdc338",
+  "providerId": "0ebdc338-6d38-11e6-b432-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-131001",
+    "series": {
+      "statistic": "mean",
+      "unitCode": "mm^-3",
+      "value": [
+        278146.0,
+        170264.0,
+        88874.4,
+        51258.8,
+        50132.7,
+        27815.8
+      ]
+    }
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:SimpleNumericalVariable",
+      "quantityType": "nsg:BBP-002001",
+      "series": {
+        "unitCode": "day",
+        "value": [
+          0.0,
+          3.0,
+          6.0,
+          12.0,
+          21.0,
+          30.0
+        ]
+      }
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/min-fields-compound-compound-ignored.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/min-fields-compound-compound-ignored.json
@@ -1,0 +1,5 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "comment": "No data on 24.09.18"
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/min-fields-simple-compound-ignored.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/min-fields-simple-compound-ignored.json
@@ -1,0 +1,5 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "comment": "No data on 24.09.18"
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-area.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-area.json
@@ -1,0 +1,35 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-position-52afbf40",
+  "providerId": "52afbf40-04bc-11e6-b795-64006a4c56ef",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:AreaTarget",
+    "hasSource": "https://doi.org/10.1038/367069a0",
+    "hasSelector": {
+      "@type": "nsg:AreaSelector",
+      "rdf:value": "page=1&viewrect=0.23699421965317918,0.8180169286577993,0.14285714285714285,0.012091898428053138",
+      "dcterms:conformsTo": "http://tools.ietf.org/rfc/rfc3778"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/dd8c0513-25e8-4aba-aa73-ef750648f250",
+      "@type": "nsg:Parameter"
+    }
+  ],
+  "keywords": [
+    {
+      "@id": "NIFORG:birnlex_254",
+      "label": "Wistar Rat"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-equation.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-equation.json
@@ -1,0 +1,47 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-equation-c3af1a82",
+  "providerId": "c3af1a82-c5a7-11e5-b8a7-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:EquationTarget",
+    "hasSource": "https://doi.org/10.1152/jn.00647.2013",
+    "hasSelector": {
+      "@type": "nsg:EquationSelector",
+      "index": "(7) and (8) and (9)"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b6ea1f34-0a31-4b3d-af7c-99cc9eee7e13",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/1eff4a5b-4b80-42c7-bfdd-ed500d4470a8",
+      "@type": "nsg:Parameter"
+    }
+  ],
+  "keywords": [
+    {
+      "@id": "nlx_151691",
+      "label": "Thalamus ventroposterior nucleus principal neuron"
+    },
+    {
+      "@id": "NIFORG:birnlex_167",
+      "label": "Mouse"
+    }
+  ],
+  "comment": "Sodium persistend current, from mesencephalic tregeminal sensory neurons rats. (m*h). Q_10 = 3"
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-figure.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-figure.json
@@ -1,0 +1,41 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-figure-1132613e",
+  "providerId": "1132613e-31b1-11e8-b594-64006a67e5d0",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:FigureTarget",
+    "hasSource": "https://doi.org/10.1097/nen.0b013e31815f3899",
+    "hasSelector": {
+      "@type": "nsg:FigureSelector",
+      "index": "1.B"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/fce8e4a0-15bf-4be1-a6ec-be08d9398c53",
+      "@type": "nsg:Parameter"
+    }
+  ],
+  "keywords": [
+    {
+      "@id": "NIFORG:birnlex_393",
+      "label": "C57BL/6J"
+    }
+  ],
+  "comment": "Used N=5.5 since in the paper it is written as 5-6.",
+  "experimentalProperties": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/9e7de368-894d-4d68-8c75-97fc251da323",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-table.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-table.json
@@ -1,0 +1,53 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-table-5ffe9b02",
+  "providerId": "5ffe9b02-ecf3-11e5-b708-64006a4c56ef",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TableTarget",
+    "hasSource": "https://doi.org/10.1152/jn.00926.2014",
+    "hasSelector": {
+      "@type": "nsg:TableSelector",
+      "index": "2",
+      "row": "11",
+      "column": "2"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/f9ee8fe4-7aa4-49b9-b34a-224c5886c12a",
+      "@type": "nsg:Parameter"
+    }
+  ],
+  "keywords": [
+    {
+      "@id": "nlx_52865",
+      "label": "Modelling"
+    },
+    {
+      "@id": "NIFINV:birnlex_2300",
+      "label": "Computational model"
+    },
+    {
+      "@id": "NIFCELL:nifext_45",
+      "label": "Thalamic reticular nucleus cell"
+    },
+    {
+      "@id": "NIFINV:birnlex_2313",
+      "label": "Neural circuit model"
+    },
+    {
+      "@id": "NIFORG:birnlex_167",
+      "label": "Mouse"
+    }
+  ],
+  "comment": "Leak conductance of a mouse TRN cell."
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-text.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-all-fields-text.json
@@ -1,0 +1,58 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ],
+  "keywords": [
+    {
+      "@id": "NIFCELL:nifext_46",
+      "label": "Thalamus interneuron small"
+    },
+    {
+      "@id": "NIFORG:birnlex_160",
+      "label": "Rat"
+    },
+    {
+      "@id": "NIFCELL:nifext_41",
+      "label": "Thalamocortical cell"
+    }
+  ],
+  "comment": "Passive properties of thalamocortical relay cells.",
+  "experimentalProperties": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/ace5b494-fa42-4190-a5f1-ed57028d7e77",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-area.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-area.json
@@ -1,0 +1,29 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-position-52afbf40",
+  "providerId": "52afbf40-04bc-11e6-b795-64006a4c56ef",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:AreaTarget",
+    "hasSource": "https://doi.org/10.1038/367069a0",
+    "hasSelector": {
+      "@type": "nsg:AreaSelector",
+      "rdf:value": "page=1&viewrect=0.23699421965317918,0.8180169286577993,0.14285714285714285,0.012091898428053138",
+      "dcterms:conformsTo": "http://tools.ietf.org/rfc/rfc3778"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/dd8c0513-25e8-4aba-aa73-ef750648f250",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-equation.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-equation.json
@@ -1,0 +1,36 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-equation-c3af1a82",
+  "providerId": "c3af1a82-c5a7-11e5-b8a7-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:EquationTarget",
+    "hasSource": "https://doi.org/10.1152/jn.00647.2013",
+    "hasSelector": {
+      "@type": "nsg:EquationSelector",
+      "index": "(7) and (8) and (9)"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b6ea1f34-0a31-4b3d-af7c-99cc9eee7e13",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/1eff4a5b-4b80-42c7-bfdd-ed500d4470a8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-figure.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-figure.json
@@ -1,0 +1,28 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-figure-1132613e",
+  "providerId": "1132613e-31b1-11e8-b594-64006a67e5d0",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:FigureTarget",
+    "hasSource": "https://doi.org/10.1097/nen.0b013e31815f3899",
+    "hasSelector": {
+      "@type": "nsg:FigureSelector",
+      "index": "1.B"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/fce8e4a0-15bf-4be1-a6ec-be08d9398c53",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-table.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-table.json
@@ -1,0 +1,30 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-table-5ffe9b02",
+  "providerId": "5ffe9b02-ecf3-11e5-b708-64006a4c56ef",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TableTarget",
+    "hasSource": "https://doi.org/10.1152/jn.00926.2014",
+    "hasSelector": {
+      "@type": "nsg:TableSelector",
+      "index": "2",
+      "row": "11",
+      "column": "2"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/f9ee8fe4-7aa4-49b9-b34a-224c5886c12a",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-text.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-min-fields-text.json
@@ -1,0 +1,37 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-all-fields-compound.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-all-fields-compound.json
@@ -1,0 +1,34 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-resting_membrane_potential-7516d66e",
+  "providerId": "7516d66e-0bb4-11e6-843d-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "quantityType": "nsg:BBP-010002",
+    "series": [
+      {
+        "statistic": "mean",
+        "unitCode": "mV",
+        "value": -74.4
+      },
+      {
+        "statistic": "sem",
+        "unitCode": "mV",
+        "value": 1.0
+      },
+      {
+        "statistic": "N",
+        "unitCode": "dimensionless",
+        "value": 29.0
+      }
+    ]
+  },
+  "requiredTag": [
+    {
+      "rootId": "sao1813327414",
+      "id": "NIFCELL:nlx_cell_20081203",
+      "label": "Thalamus relay cell"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-all-fields-simple.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-all-fields-simple.json
@@ -1,0 +1,21 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-cell_area-870f0288",
+  "providerId": "870f0288-061b-11e6-9d1c-c869cd917532",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-121003",
+    "series": {
+      "unitCode": "um^2",
+      "value": 9864.0
+    }
+  },
+  "requiredTag": [
+    {
+      "rootId": "sao1813327414",
+      "id": "NIFCELL:nifext_46",
+      "label": "Thalamus interneuron small"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-min-fields-compound.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-min-fields-compound.json
@@ -1,0 +1,27 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-resting_membrane_potential-7516d66e",
+  "providerId": "7516d66e-0bb4-11e6-843d-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "quantityType": "nsg:BBP-010002",
+    "series": [
+      {
+        "statistic": "mean",
+        "unitCode": "mV",
+        "value": -74.4
+      },
+      {
+        "statistic": "sem",
+        "unitCode": "mV",
+        "value": 1.0
+      },
+      {
+        "statistic": "N",
+        "unitCode": "dimensionless",
+        "value": 29.0
+      }
+    ]
+  }
+}

--- a/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-min-fields-simple.json
+++ b/modules/literatureannotation/src/test/resources/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-min-fields-simple.json
@@ -1,0 +1,14 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-cell_area-870f0288",
+  "providerId": "870f0288-061b-11e6-9d1c-c869cd917532",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-121003",
+    "series": {
+      "unitCode": "um^2",
+      "value": 9864.0
+    }
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/functionparameter/v0.1.0/auto-missing-equation.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/functionparameter/v0.1.0/auto-missing-equation.json
@@ -1,0 +1,18 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:FunctionParameter",
+  "name": "p-prop_inact_ion_curr-71233092",
+  "providerId": "71233092-eb80-11e5-a9b7-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:AlgebraicVariable",
+    "quantityType": "nsg:BBP-050002",
+    "unitCode": "dimensionless"
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:AlgebraicVariable",
+      "quantityType": "nsg:BBP-010001",
+      "unitCode": "mV"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-missing-indpendentvariable-simple.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/auto-missing-indpendentvariable-simple.json
@@ -1,0 +1,22 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "name": "p-neuron_density-0ebdc338",
+  "providerId": "0ebdc338-6d38-11e6-b432-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-131001",
+    "series": {
+      "statistic": "mean",
+      "unitCode": "mm^-3",
+      "value": [
+        278146.0,
+        170264.0,
+        88874.4,
+        51258.8,
+        50132.7,
+        27815.8
+      ]
+    }
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/independentvariable-series-compound-instead-simple.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/independentvariable-series-compound-instead-simple.json
@@ -1,0 +1,54 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "name": "p-neuron_density-0ebdc338",
+  "providerId": "0ebdc338-6d38-11e6-b432-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-131001",
+    "series": {
+      "statistic": "mean",
+      "unitCode": "mm^-3",
+      "value": [
+        278146.0,
+        170264.0,
+        88874.4,
+        51258.8,
+        50132.7,
+        27815.8
+      ]
+    }
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:SimpleNumericalVariable",
+      "quantityType": "nsg:BBP-002001",
+      "series": [
+        {
+          "statistic": "mean",
+          "unitCode": "dimensionless",
+          "value": [
+            109.6,
+            81.6
+          ]
+        },
+        {
+          "statistic": "sem",
+          "unitCode": "dimensionless",
+          "value": [
+            27.1,
+            15.1
+          ]
+        },
+        {
+          "statistic": "N",
+          "unitCode": "dimensionless",
+          "value": [
+            15.0,
+            16.0
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/independentvariable-series-simple-instead-compound.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/numericaltraceparameter/v0.1.0/independentvariable-series-simple-instead-compound.json
@@ -1,0 +1,39 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:NumericalTraceParameter",
+  "name": "p-neuron_density-0ebdc338",
+  "providerId": "0ebdc338-6d38-11e6-b432-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-131001",
+    "series": {
+      "statistic": "mean",
+      "unitCode": "mm^-3",
+      "value": [
+        278146.0,
+        170264.0,
+        88874.4,
+        51258.8,
+        50132.7,
+        27815.8
+      ]
+    }
+  },
+  "independentVariable": [
+    {
+      "@type": "nsg:CompoundNumericalVariable",
+      "quantityType": "nsg:BBP-002001",
+      "series": {
+        "unitCode": "day",
+        "value": [
+          0.0,
+          3.0,
+          6.0,
+          12.0,
+          21.0,
+          30.0
+        ]
+      }
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-contribution.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-contribution.json
@@ -1,0 +1,25 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-contributionshape-agent.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-contributionshape-agent.json
@@ -1,0 +1,26 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {},
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-entityshape-name.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-entityshape-name.json
@@ -1,0 +1,36 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-fragmentselectorshape-conformsto.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-fragmentselectorshape-conformsto.json
@@ -1,0 +1,28 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-position-52afbf40",
+  "providerId": "52afbf40-04bc-11e6-b795-64006a4c56ef",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:AreaTarget",
+    "hasSource": "https://doi.org/10.1038/367069a0",
+    "hasSelector": {
+      "@type": "nsg:AreaSelector",
+      "rdf:value": "page=1&viewrect=0.23699421965317918,0.8180169286577993,0.14285714285714285,0.012091898428053138"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/dd8c0513-25e8-4aba-aa73-ef750648f250",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-fragmentselectorshape-value.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-fragmentselectorshape-value.json
@@ -1,0 +1,28 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-position-52afbf40",
+  "providerId": "52afbf40-04bc-11e6-b795-64006a4c56ef",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:AreaTarget",
+    "hasSource": "https://doi.org/10.1038/367069a0",
+    "hasSelector": {
+      "@type": "nsg:AreaSelector",
+      "dcterms:conformsTo": "http://tools.ietf.org/rfc/rfc3778"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/dd8c0513-25e8-4aba-aa73-ef750648f250",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-hasbody.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-hasbody.json
@@ -1,0 +1,27 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-hastarget.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-hastarget.json
@@ -1,0 +1,28 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-indexselectorshape-index.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-indexselectorshape-index.json
@@ -1,0 +1,27 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-figure-1132613e",
+  "providerId": "1132613e-31b1-11e8-b594-64006a67e5d0",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:FigureTarget",
+    "hasSource": "https://doi.org/10.1097/nen.0b013e31815f3899",
+    "hasSelector": {
+      "@type": "nsg:FigureSelector"
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/fce8e4a0-15bf-4be1-a6ec-be08d9398c53",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-selectortargetshape-hassource.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-selectortargetshape-hassource.json
@@ -1,0 +1,36 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-textpositionselectorshape-end.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-textpositionselectorshape-end.json
@@ -1,0 +1,36 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-textpositionselectorshape-start.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-textpositionselectorshape-start.json
@@ -1,0 +1,36 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "end": 23212
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-textpositiontargetshape-hasselector.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/auto-missing-textpositiontargetshape-hasselector.json
@@ -1,0 +1,32 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015"
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/b0435a19-dcde-4828-9e7e-7a1d7792b1a9",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/0fe01a40-5c9c-4f9a-a673-9224e50c28c8",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/empty-contributionshape-agent.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/empty-contributionshape-agent.json
@@ -1,0 +1,28 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": []
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  },
+  "hasBody": [
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/402717da-d261-4cf7-a329-b33bd997be60",
+      "@type": "nsg:Parameter"
+    },
+    {
+      "@id": "{{base}}/data/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/f86facd0-2dbe-4d80-9371-c98f86854db7",
+      "@type": "nsg:Parameter"
+    }
+  ]
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/empty-hasbody.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/parameterannotation/v0.1.0/empty-hasbody.json
@@ -1,0 +1,28 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:ParameterAnnotation",
+  "name": "a-text-e6914b74",
+  "providerId": "e6914b74-ed2a-11e5-b291-3417ebb8f5ca",
+  "contribution": {
+    "agent": [
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/575c0c49-3203-4dc7-813b-2903680b6b8a",
+        "@type": "prov:Agent"
+      },
+      {
+        "@id": "{{base}}/data/neurosciencegraph/contributor/agent/v0.1.0/124d1066-41cd-4d1b-b0ad-eed2672cf927",
+        "@type": "prov:Agent"
+      }
+    ]
+  },
+  "hasTarget": {
+    "@type": "nsg:TextPositionTarget",
+    "hasSource": "https://doi.org/10.1523/JNEUROSCI.2740-15.2015",
+    "hasSelector": {
+      "@type": "nsg:TextPositionSelector",
+      "start": 23171,
+      "end": 23212
+    }
+  },
+  "hasBody": []
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-algebraicvalueshape-unitcode-simple.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-algebraicvalueshape-unitcode-simple.json
@@ -1,0 +1,13 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-cell_area-870f0288",
+  "providerId": "870f0288-061b-11e6-9d1c-c869cd917532",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-121003",
+    "series": {
+      "value": 9864.0
+    }
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-series-compound.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-series-compound.json
@@ -1,0 +1,10 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-resting_membrane_potential-7516d66e",
+  "providerId": "7516d66e-0bb4-11e6-843d-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "quantityType": "nsg:BBP-010002"
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-series-simple.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-series-simple.json
@@ -1,0 +1,10 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-cell_area-870f0288",
+  "providerId": "870f0288-061b-11e6-9d1c-c869cd917532",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-121003"
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-valueshape-value-simple.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-valueshape-value-simple.json
@@ -1,0 +1,13 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-cell_area-870f0288",
+  "providerId": "870f0288-061b-11e6-9d1c-c869cd917532",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-121003",
+    "series": {
+      "unitCode": "um^2"
+    }
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-variableshape-quantitytype-compound.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-variableshape-quantitytype-compound.json
@@ -1,0 +1,26 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-resting_membrane_potential-7516d66e",
+  "providerId": "7516d66e-0bb4-11e6-843d-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "series": [
+      {
+        "statistic": "mean",
+        "unitCode": "mV",
+        "value": -74.4
+      },
+      {
+        "statistic": "sem",
+        "unitCode": "mV",
+        "value": 1.0
+      },
+      {
+        "statistic": "N",
+        "unitCode": "dimensionless",
+        "value": 29.0
+      }
+    ]
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-variableshape-quantitytype-simple.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/auto-missing-variableshape-quantitytype-simple.json
@@ -1,0 +1,13 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-cell_area-870f0288",
+  "providerId": "870f0288-061b-11e6-9d1c-c869cd917532",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "series": {
+      "unitCode": "um^2",
+      "value": 9864.0
+    }
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/missing-algebraicvalueshape-unitcode-compound.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/missing-algebraicvalueshape-unitcode-compound.json
@@ -1,0 +1,26 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-resting_membrane_potential-7516d66e",
+  "providerId": "7516d66e-0bb4-11e6-843d-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "quantityType": "nsg:BBP-010002",
+    "series": [
+      {
+        "statistic": "mean",
+        "unitCode": "mV",
+        "value": -74.4
+      },
+      {
+        "statistic": "sem",
+        "value": 1.0
+      },
+      {
+        "statistic": "N",
+        "unitCode": "dimensionless",
+        "value": 29.0
+      }
+    ]
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/missing-valueshape-value-compound.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/missing-valueshape-value-compound.json
@@ -1,0 +1,26 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-resting_membrane_potential-7516d66e",
+  "providerId": "7516d66e-0bb4-11e6-843d-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "quantityType": "nsg:BBP-010002",
+    "series": [
+      {
+        "statistic": "mean",
+        "unitCode": "mV",
+        "value": -74.4
+      },
+      {
+        "statistic": "sem",
+        "unitCode": "mV"
+      },
+      {
+        "statistic": "N",
+        "unitCode": "dimensionless",
+        "value": 29.0
+      }
+    ]
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/series-compound-instead-simple.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/series-compound-instead-simple.json
@@ -1,0 +1,27 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-cell_area-870f0288",
+  "providerId": "870f0288-061b-11e6-9d1c-c869cd917532",
+  "dependentVariable": {
+    "@type": "nsg:SimpleNumericalVariable",
+    "quantityType": "nsg:BBP-121003",
+    "series": [
+      {
+        "statistic": "mean",
+        "unitCode": "mV",
+        "value": -74.4
+      },
+      {
+        "statistic": "sem",
+        "unitCode": "mV",
+        "value": 1.0
+      },
+      {
+        "statistic": "N",
+        "unitCode": "dimensionless",
+        "value": 29.0
+      }
+    ]
+  }
+}

--- a/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/series-simple-instead-compound.json
+++ b/modules/literatureannotation/src/test/resources/invalid/neurosciencegraph/literatureannotation/pointvalueparameter/v0.1.0/series-simple-instead-compound.json
@@ -1,0 +1,14 @@
+{
+  "@context": "{{base}}/contexts/neurosciencegraph/core/data/v1.0.4",
+  "@type": "nsg:PointValueParameter",
+  "name": "p-resting_membrane_potential-7516d66e",
+  "providerId": "7516d66e-0bb4-11e6-843d-64006a4c56ef",
+  "dependentVariable": {
+    "@type": "nsg:CompoundNumericalVariable",
+    "quantityType": "nsg:BBP-010002",
+    "series": {
+      "unitCode": "um^2",
+      "value": 9864.0
+    }
+  }
+}


### PR DESCRIPTION
Hello,

Here is the first iteration of the Literature Annotation domain model.

It's goal is to achieve #51. It is related to #43 and #49.

Created SHACL shapes are compliant with [W3C Web Annotation](https://www.w3.org/TR/annotation-model/) recommendations.

Known current limitations:

1 - **Annotation of facts** are not modelled yet. These annotations do not have parameters.

2 - Literature references are not modelled yet. Reason: prioritization and some work has already been done on the subject in #43. TODO: Contribute to @apdavison proposition.

3 - Provenance is not modelled explicitly yet. Implicitly, it is:
* parameters are linked to an annotation (`hasBody`),
* annotations have SelectorTarget objects (`hasTarget`) which describe precisely where the information come from in the literature reference (`hasSelector`) and which literature reference it is (`hasSource`).
* agents are known and linked with each annotation (`contribution.agent`).

4 - The NeuroCurator field 'relationship' which describes more precisely on what the measure of a parameter is has not been modelled yet.

5 - `rdf:value` and `dcterms:conformsTo` has not been added to `/contexts/neurosciencegraph/core/data/vx.x.x` yet.

6 - `schema:unitCode` has been explicitly asked to be used instead of `schema:unitText` even though values corresponds to the later definition for now.

7 - Literature references without DOI or PMID are currently not modelled for the `hasSource` property.


Known tricky cases:

8 - Should `TargetShape` exists?

9 - Should `BodyShape` exists?

10 - There is no check at the SHACL level to declare invalid instances with a required property with an empty string as value.