### PR TITLE
Created imagestack/v0.2.1 schema

### DIFF
--- a/modules/atlas/src/main/resources/schemas/neurosciencegraph/atlas/imagestack/v0.2.1.json
+++ b/modules/atlas/src/main/resources/schemas/neurosciencegraph/atlas/imagestack/v0.2.1.json
@@ -2,7 +2,7 @@
   "@context": [
     "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
     {
-      "this": "{{base}}/schemas/neurosciencegraph/atlas/imagestack/v0.2.0/shapes/"
+      "this": "{{base}}/schemas/neurosciencegraph/atlas/imagestack/v0.2.1/shapes/"
     }
   ],
   "@type": "nxv:Schema",

--- a/modules/atlas/src/main/resources/schemas/neurosciencegraph/atlas/imagestack/v0.2.1.json
+++ b/modules/atlas/src/main/resources/schemas/neurosciencegraph/atlas/imagestack/v0.2.1.json
@@ -1,0 +1,136 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "this": "{{base}}/schemas/neurosciencegraph/atlas/imagestack/v0.2.0/shapes/"
+    }
+  ],
+  "@type": "nxv:Schema",
+  "import": [
+    "{{base}}/schemas/neurosciencegraph/commons/transformableobject/v1.0.0",
+    "{{base}}/schemas/neurosciencegraph/commons/quantitativevalue/v0.1.2",
+    "{{base}}/schemas/neurosciencegraph/atlas/rotationalmatrix/v0.1.0"
+  ],
+  "shapes": [
+    {
+      "@id": "this:ImageStackShape",
+      "@type": "sh:NodeShape",
+      "label": "Image stack",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "targetClass": "nsg:ImageStack",
+      "and": [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/transformableobject/v1.0.0/shapes/TransformableObjectShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:imageModality",
+              "name": "Image modality",
+              "description": "Modality of the image stack",
+              "datatype": "xsd:string",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:slicingPlane",
+              "name": "Slicing plane",
+              "description": "Slicing plane of the brain",
+              "in": [
+                "Sagittal",
+                "Para-sagittal",
+                "Coronal",
+                "Horizontal"
+              ],
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:sliceWidth",
+              "name": "Slice width",
+              "description": "Width of the 2D slice",
+              "datatype": "xsd:integer",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:sliceHeight",
+              "name": "Slice height",
+              "description": "Height of the 2D slice",
+              "datatype": "xsd:integer",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:sliceResolution",
+              "name": "Slice resolution",
+              "description": "Resolution of the 2D slice",
+              "node": "this:SliceResolutionShape",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:numberOfSlices",
+              "name": "Number of slices",
+              "description": "Number of slices of the image stack",
+              "datatype": "xsd:integer",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:sliceInterval",
+              "name": "Slice interval",
+              "description": "Slice interval",
+              "node": "this:SliceIntervalShape",
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "this:SliceResolutionShape",
+      "@type": "sh:NodeShape",
+      "and" : [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/quantitativevalue/v0.1.2/QuantitativeValueShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:widthResolution",
+              "name": "Width resolution",
+              "description": "Slice resolution in width",
+              "datatype": "xsd:float",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:heightResolution",
+              "name": "Height resolution",
+              "description": "Slice height",
+              "datatype": "xsd:float",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "this:SliceIntervalShape",
+      "@type": "sh:NodeShape",
+      "and" : [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/quantitativevalue/v0.1.2/QuantitativeValueShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:sliceIntervalValue",
+              "name": "Slice interval value",
+              "description": "Slice interval value",
+              "datatype": "xsd:float",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* removed minCount constraint on property shapes
* replaced property shape "sliceDirection" with "slicingPlane" to align with property shape in BrainSlicing schema
* updated import to transformableobject/v1.0.0 (latest version)

Fixes https://github.com/INCF/neuroshapes/issues/205 