### PR TITLE
Fix EModelBuilding

### DIFF
--- a/modules/simulation/src/main/resources/schemas/neurosciencegraph/simulation/emodelbuilding/v0.1.5.json
+++ b/modules/simulation/src/main/resources/schemas/neurosciencegraph/simulation/emodelbuilding/v0.1.5.json
@@ -1,0 +1,54 @@
+{
+  "@context": [
+    "{{base}}/contexts/neurosciencegraph/core/schema/v0.1.0",
+    {
+      "this": "{{base}}/schemas/neurosciencegraph/simulation/emodelbuilding/v0.1.5/shapes/"
+    }
+  ],
+  "@type": "nxv:Schema",
+  "imports": [
+    "{{base}}/schemas/neurosciencegraph/commons/activity/v0.1.4",
+    "{{base}}/schemas/neurosciencegraph/commons/quantitativevalue/v0.1.2"
+  ],
+  "shapes": [
+    {
+      "@id": "this:EModelBuildingShape",
+      "@type": "sh:NodeShape",
+      "label": "Emodel building shape",
+      "targetClass": "nsg:EModelBuilding",
+      "nodekind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "{{base}}/schemas/neurosciencegraph/commons/activity/v0.1.4/ActivityShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:bestScore",
+              "name": "Best score",
+              "description": "Best score.",
+              "node": "{{base}}/schemas/neurosciencegraph/commons/quantitativevalue/v0.1.2/shapes/QuantitativeValueShape",
+              "maxCount": 1
+            },
+            {
+              "path": "prov:used",
+              "name": "Used",
+              "description": "Morphology which was used to fit model parameters.",
+              "class": "nsg:ReconstructedCell",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "prov:generated",
+              "name": "Generated",
+              "description": "The generated Emodel",
+              "class": "nsg:EModel",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Removed {{base}}/schemas/neurosciencegraph/simulation/emodel imports because it is not used during the validation process.