### PR TITLE
Added ModelProject shape

### DIFF
--- a/modules/simulation/src/main/resources/schemas/neurosciencegraph/simulation/modelproject/v0.1.0.json
+++ b/modules/simulation/src/main/resources/schemas/neurosciencegraph/simulation/modelproject/v0.1.0.json
@@ -1,0 +1,130 @@
+{
+    "@context": [
+    	{
+            "imports": {
+                "@id": "owl:imports",
+                "@type": "@id",
+                "@container": "@set"
+            },
+            "owl": "http://www.w3.org/2002/07/owl#"
+        },
+        "https://nexus-int.humanbrainproject.org/v0/contexts/nexus/core/resource/v0.3.0",
+        "https://nexus-int.humanbrainproject.org/v0/contexts/neurosciencegraph/core/schema/v0.1.0",
+        {
+            "this": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/simulation/modelproject/v0.1.0/shapes/"
+        }
+    ],
+    "@type": "nxv:Schema",
+    "imports": [
+        "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/entity/v0.1.0",
+        "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/typedlabeledontologyterm/v0.1.2"
+    ],
+    "shapes": [{
+        "@id": "this:ModelProjectShape",
+        "@type": "sh:NodeShape",
+        "label": "This shape represents a modelling project, and is a way to link related ModelInstances",
+        "nodekind": "sh:BlankNodeOrIRI",
+        "targetClass": "nsg:ModelProject",
+        "and": [{
+                "node": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/entity/v0.1.0/shapes/EntityShape"
+            },
+            {
+                "property": [{
+                        "path": "nsg:modelOf",
+                        "name": "Model of",
+                        "description": "Models of many things such as cells, ion channels, circuits, whole brains,...",
+                        "editorialNote": "The value of this property should be constrained by a sh:class corresponding to what is being modeled."
+                    },
+                    {
+                        "path": "schema:name",
+                        "name": "Name",
+                        "description": "the name of the model project",
+                        "datatype": "xsd:string",
+                        "mincount": "1",
+                        "maxcount": "1"
+                    },
+                    {
+                        "path": "nsg:alias",
+                        "name": "Alias",
+                        "description": "the alias of the model project.",
+                        "editorialNote": "used as an identifier, should be unique.",
+                        "datatype": "xsd:string",
+                        "maxcount": "1"
+                    },
+                    {
+                        "path": "nsg:brainRegion",
+                        "name": "Brain region",
+                        "description": "Brain region",
+                        "node": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/typedlabeledontologyterm/v0.1.2/shapes/BrainRegionOntologyTermShape"
+                    },
+                    {
+                        "path": "nsg:species",
+                        "name": "Species",
+                        "description": "Species",
+                        "node": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/typedlabeledontologyterm/v0.1.2/shapes/SpeciesOntologyTermShape"
+                    },
+                    {
+                        "path": "nsg:celltype",
+                        "name": "Cell type",
+                        "description": "Cell type",
+                        "node": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/typedlabeledontologyterm/v0.1.2/shapes/CellTypeOntologyTermShape"
+                    },
+                    {
+                        "path": "nsg:organization",
+                        "name": "Organization",
+                        "description": "Organization",
+                        "node": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/organization/v0.1.0/shapes/OrganizationShape"
+                    },
+                    {
+                        "path": "nsg:abstractionLevel",
+                        "name": "Abstraction Level",
+                        "description": "Abstraction level of the model",
+                        "node": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/typedlabeledontologyterm/v0.1.2/shapes/AbstractionLevelOntologyTermShape"
+                    },
+                    {
+                        "path": "nsg:private",
+                        "name": "Private",
+                        "description": "a boolean flag indicating whether access to the model should be restricted",
+                        "datatype": "xsd:boolean"
+                    },
+                    {
+                        "path": "schema:author",
+                        "name": "Author",
+                        "description": "Author of the model Project",
+                        "node": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/person/v0.1.0/shapes/PersonShape",
+                        "mincount": "1"
+                    },
+                    {
+                        "path": "nsg:owner",
+                        "name": "Owner",
+                        "description": "Owner of the model Project",
+                        "node": "https://nexus-int.humanbrainproject.org/v0/schemas/neuralactivity/commons/person/v0.1.0/shapes/PersonShape",
+                        "maxcount": "1",
+                        "mincount": "1"
+                    },
+                    {
+                        "path": "schema:description",
+                        "name": "Description",
+                        "description": "model project description",
+                        "datatype": "xsd:string",
+                        "mincount": "1",
+                        "maxcount": "1"
+                    },
+                    {
+                        "path": "nsg:collabID",
+                        "name": "collab id",
+                        "description": "collab id of the model project",
+                        "datatype": "xsd:int"
+                    },
+                    {
+                        "path": "nsg:PLAComponents",
+                        "name": "PLA components",
+                        "description": "PLA components",
+                        "datatype": "xsd:string"
+                    }
+
+                ]
+            }
+        ]
+    }]
+}

--- a/modules/simulation/src/main/resources/schemas/neurosciencegraph/simulation/modelproject/v0.1.0.json
+++ b/modules/simulation/src/main/resources/schemas/neurosciencegraph/simulation/modelproject/v0.1.0.json
@@ -113,16 +113,22 @@
                     {
                         "path": "nsg:collabID",
                         "name": "collab id",
-                        "description": "collab id of the model project",
+                        "description": "collab id of the model project.",
+                        "editorialNote": "Note that this is not generic, and should be removed in a future schema version, but is retained here for short-term convenience.",
                         "datatype": "xsd:int"
                     },
                     {
-                        "path": "nsg:PLAComponents",
-                        "name": "PLA components",
-                        "description": "PLA components",
+                        "path": "schema:funder",
+                        "name": "Funding",
+                        "description": "Information about the funding for this project",
+                        "datatype": "xsd:string"
+                    },
+                    {
+                        "path": "nsg:providerId",
+                        "name": "Provider ID",
+                        "description": "An existing, alternative id of the model project",
                         "datatype": "xsd:string"
                     }
-
                 ]
             }
         ]


### PR DESCRIPTION
This is a mechanism for grouping ModelInstances (and subclasses) where all the instances are models of the same thing.

(e.g. in an analogy with Git, a ModelInstance is an individual version, whereas a ModelProject represents the repository).

This is currently needed for the migration of the HBP Model Catalog to the HBP Knowledge Graph.