### PR TITLE
Fixed AgeShape in subject schema

### DIFF
--- a/shapes/neurosciencegraph/commons/quantitativevalue/schema.json
+++ b/shapes/neurosciencegraph/commons/quantitativevalue/schema.json
@@ -30,6 +30,9 @@
             },
             {
               "datatype": "xsd:double"
+            },
+            {
+              "datatype": "xsd:integer"
             }
           ],
           "minCount": 1,

--- a/shapes/neurosciencegraph/commons/subject/schema.json
+++ b/shapes/neurosciencegraph/commons/subject/schema.json
@@ -119,23 +119,23 @@
     {
       "@id": "this:AgeShape",
       "@type": "sh:NodeShape",
-      "property": [
+      "and": [
         {
-          "path": "nsg:period",
-          "name": "Period",
-          "in": [
-            "Pre-natal",
-            "Post-natal"
-          ],
-          "minCount": 1,
-          "maxCount": 1
+          "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape"
         },
         {
-          "path": "schema:value",
-          "name": "Age value",
-          "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape",
-          "minCount": 1,
-          "maxCount": 1
+          "property": [
+            {
+              "path": "nsg:period",
+              "name": "Period",
+              "in": [
+                "Pre-natal",
+                "Post-natal"
+              ],
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
         }
       ]
     }

--- a/shapes/neurosciencegraph/datashapes/core/subject/examples/subject.json
+++ b/shapes/neurosciencegraph/datashapes/core/subject/examples/subject.json
@@ -1,0 +1,27 @@
+{
+  "@context": [
+    "https://neuroshapes.org",
+  ],
+  "@id": "mySubject",
+  "@type": [
+    "Entity",
+    "Subject"
+  ],
+  "name": "My subject",
+  "species": {
+    "@id": "https://www.ncbi.nlm.nih.gov/taxonomy/10090",
+    "label": "Mus musculus"
+  },
+  "strain": {
+    "@id": "http://www.mousemine.org/mousemine/portal.do?class=Strain&externalids=MGI:2159769",
+    "label": "C57BL/6"
+  },
+  "age": {
+    "period": "Post-natal",
+    "value": {
+      "@value": "15",
+      "@type": "xsd:decimal"
+    },
+    "unitCode": "days"
+  }
+}

--- a/shapes/neurosciencegraph/datashapes/core/subject/examples/subject.json
+++ b/shapes/neurosciencegraph/datashapes/core/subject/examples/subject.json
@@ -1,8 +1,7 @@
 {
-  "@context": [
-    "https://neuroshapes.org",
+  "@context": "https://incf.github.io/neuroshapes/contexts/data.json",
   ],
-  "@id": "mySubject",
+  "@id": "http://example.org/neurosciencegraph/data/subject/uuid",
   "@type": [
     "Entity",
     "Subject"
@@ -13,14 +12,14 @@
     "label": "Mus musculus"
   },
   "strain": {
-    "@id": "http://www.mousemine.org/mousemine/portal.do?class=Strain&externalids=MGI:2159769",
+    "@id": "http://www.ebi.ac.uk/efo/EFO_0004472",
     "label": "C57BL/6"
   },
   "age": {
     "period": "Post-natal",
     "value": {
       "@value": "15",
-      "@type": "xsd:decimal"
+      "@type": "xsd:integer"
     },
     "unitCode": "days"
   }

--- a/shapes/neurosciencegraph/datashapes/core/subject/examples/subject.json
+++ b/shapes/neurosciencegraph/datashapes/core/subject/examples/subject.json
@@ -1,6 +1,5 @@
 {
   "@context": "https://incf.github.io/neuroshapes/contexts/data.json",
-  ],
   "@id": "http://example.org/neurosciencegraph/data/subject/uuid",
   "@type": [
     "Entity",


### PR DESCRIPTION
Removed the schema:value property shape and included the QuantitativeValueShape directly as a node under the "and" operator.