### PR TITLE
Fixed WithUnitCodeShape to prevent schema:unitCode to contain itself

### DIFF
--- a/shapes/neurosciencegraph/commons/identifier/schema.json
+++ b/shapes/neurosciencegraph/commons/identifier/schema.json
@@ -17,9 +17,10 @@
       "@type": "sh:NodeShape",
       "property": [
         {
+          "@id": "this:WithIdentifierPropertyShape",
           "path": "schema:identifier",
           "name": "Identifier",
-          "description": "A landing page describing the dataset.",
+          "description": "The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs.",
           "xone": [
             {
               "nodeKind": "sh:IRI"
@@ -33,13 +34,6 @@
           ]
         }
       ]
-    },
-    {
-      "@id": "this:WithIdentifierPropertyShape",
-      "@type": "sh:PropertyShape",
-      "label": "Schema.org identifier shape.",
-      "path": "schema:identifier",
-      "node": "https://neuroshapes.org/commons/identifier/shapes/IdentifierShape"
     },
     {
       "@id": "this:WithStructuredIdentifierShape",

--- a/shapes/neurosciencegraph/commons/propertyvalue/schema.json
+++ b/shapes/neurosciencegraph/commons/propertyvalue/schema.json
@@ -24,7 +24,6 @@
           "path": "schema:value",
           "name": "Value",
           "description": "The property value.",
-          "datatype": "xsd:string",
           "maxCount": 1
         }
       ]

--- a/shapes/neurosciencegraph/commons/unit/schema.json
+++ b/shapes/neurosciencegraph/commons/unit/schema.json
@@ -36,7 +36,14 @@
       "@type": "sh:PropertyShape",
       "path": "schema:unitCode",
       "name": "Unit code",
-      "node": "this:UnitShape",
+      "or": [
+        {
+          "node": "https://neuroshapes.org/commons/labeledontologyentity/shapes/LabeledOntologyEntityShape"
+        },
+        {
+          "datatype": "xsd:string"
+        }
+      ],
       "minCount": 1
     }
   ]

--- a/shapes/neurosciencegraph/commons/unit/schema.json
+++ b/shapes/neurosciencegraph/commons/unit/schema.json
@@ -17,6 +17,7 @@
       "@type": "sh:NodeShape",
       "property": [
         {
+          "@id": "this:WithUnitCodeShape",
           "path": "schema:unitCode",
           "name": "Unit",
           "or": [
@@ -30,21 +31,6 @@
           "minCount": 1
         }
       ]
-    },
-    {
-      "@id": "this:WithUnitCodeShape",
-      "@type": "sh:PropertyShape",
-      "path": "schema:unitCode",
-      "name": "Unit code",
-      "or": [
-        {
-          "node": "https://neuroshapes.org/commons/labeledontologyentity/shapes/LabeledOntologyEntityShape"
-        },
-        {
-          "datatype": "xsd:string"
-        }
-      ],
-      "minCount": 1
     }
   ]
 }


### PR DESCRIPTION
* Embedded  WithIdentifierPropertyShape as property shape within https://neuroshapes.org/commons/identifier/shapes/IdentifierShape

* Embedded  WithUnitCodeShape as property shape within https://neuroshapes.org/commons/unit/shapes/UnitCodeShape 

* Removed datatype constraint for value in https://neuroshapes.org/commons/propertyvalue/shapes/PropertyValueShape
