### PR TITLE
add workflow engine shape

### DIFF
--- a/shapes/neurosciencegraph/datashapes/core/workflowengine/schema.json
+++ b/shapes/neurosciencegraph/datashapes/core/workflowengine/schema.json
@@ -1,0 +1,79 @@
+{
+  "@context": [
+    "https://incf.github.io/neuroshapes/contexts/schema.json",
+    {
+      "this": "https://neuroshapes.org/dash/workflowengine/shapes/"
+    }
+  ],
+  "@id": "https://neuroshapes.org/dash/workflowengine",
+  "@type": "nxv:Schema",
+  "imports": [
+    "https://neuroshapes.org/dash/softwareagent",
+    "https://neuroshapes.org/commons/entity"
+  ],
+  "shapes": [
+    {
+      "@id": "this:WorkflowEngineShape",
+      "@type": "sh:NodeShape",
+      "description": "Software agent which executes automated workflows.",
+      "targetClass": "nsg:WorkflowEngine",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "https://neuroshapes.org/dash/softwareagent/shapes/SoftwareAgentShape"
+        },
+        {
+          "property": [
+            {
+              "path": "schema:name",
+              "name": "Name.",
+              "description": "Name of the workflow that engine was running.",
+              "datatype": "xsd:string",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "schema:description",
+              "name": "Description.",
+              "description": "Optional description of the workflow.",
+              "datatype": "xsd:string",
+              "maxCount": 1
+            },
+            {
+              "path": "schema:version",
+              "name": "Version.",
+              "description": "Version of the workflow engine.",
+              "datatype": "xsd:string",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:parameter",
+              "name": "Parameter.",
+              "description": "Parameters which were used to run the workflow.",
+              "datatype": "xsd:string",
+              "minCount": 1,
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:configuration",
+              "name": "Workflow Engine Configuration file.",
+              "description": "Workflow configuration file.",
+              "class": "nsg:Configuration",
+              "node":"https://neuroshapes.org/commons/entity/shapes/EntityShape",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:task",
+              "name": "Task file.",
+              "description": "Workflow tasks definition file.",
+              "class": "prov:Entity",
+              "node":"https://neuroshapes.org/commons/entity/shapes/EntityShape",
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/shapes/prov/commons/agent/schema.json
+++ b/shapes/prov/commons/agent/schema.json
@@ -10,7 +10,7 @@
   "prov:wasDerivedFrom": "https://github.com/BlueBrain/nexus-prov/blob/v1.2.0/modules/prov/src/main/resources/schemas/nexus/provsh/agent/v1.0.0.json",
   "shapes": [
     {
-      "@id": "Agent",
+      "@id": "AgentShape",
       "@type": "sh:NodeShape",
       "label": "Agent shape",
       "comment": "An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity.",

--- a/shapes/prov/datashapes/agent/schema.json
+++ b/shapes/prov/datashapes/agent/schema.json
@@ -13,7 +13,7 @@
   "prov:wasDerivedFrom": "https://github.com/BlueBrain/nexus-prov/blob/v1.2.0/modules/prov/src/main/resources/schemas/nexus/prov/agent/v1.0.0.json",
   "shapes": [
     {
-      "@id": "Agent",
+      "@id": "AgentShape",
       "@type": "sh:NodeShape",
       "label": "Agent shape",
       "comment": "An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity.",


### PR DESCRIPTION
Provides the schema for the workflow engine executions with all the used parameters(to be able to reproduce it). All the entities which are created as a result of the workflow execution will link to it with the `wasAttributedTo`.
Also includes some fixes to the agent schema.