### PR TITLE
Added skos:note shape to the commons/annotation schema

### DIFF
--- a/shapes/neurosciencegraph/commons/annotation/schema.json
+++ b/shapes/neurosciencegraph/commons/annotation/schema.json
@@ -36,6 +36,7 @@
               "path": "nsg:hasBody",
               "name": "Body",
               "description": "The entity or value that the target entity is being annotated with.",
+              "class": "nsg:AnnotationBody",
               "node": "this:HasBodyShape"
             },
             {
@@ -154,7 +155,6 @@
     {
       "@id": "this:HasBodyShape",
       "@type": "sh:NodeShape",
-      "class": "nsg:AnnotationBody",
       "nodeKind": "sh:BlankNodeOrIRI",
       "property": [
         {

--- a/shapes/neurosciencegraph/commons/annotation/schema.json
+++ b/shapes/neurosciencegraph/commons/annotation/schema.json
@@ -42,7 +42,7 @@
             {
               "path": "skos:note",
               "name": "Note",
-              "description": "A general note, for any purpose. This could e.g. include reasons on which an annotation - such as an mType classification - was based.",
+              "description": "A general note, for any purpose. This could include reasons on which an annotation - such as an mType classification - was based.",
               "datatype": "xsd:string"
             }
           ]
@@ -160,7 +160,7 @@
         {
           "path": "skos:note",
           "name": "Note",
-          "description": "A general note, for any purpose. This could e.g. include reasons on which an annotation - such as an mType classification - was based.",
+          "description": "A general note, for any purpose. This could include reasons on which an annotation - such as an mType classification - was based.",
           "datatype": "xsd:string"
         }
 

--- a/shapes/neurosciencegraph/commons/annotation/schema.json
+++ b/shapes/neurosciencegraph/commons/annotation/schema.json
@@ -36,8 +36,13 @@
               "path": "nsg:hasBody",
               "name": "Body",
               "description": "The entity or value that the target entity is being annotated with.",
-              "class": "nsg:AnnotationBody",
-              "nodeKind": "sh:BlankNodeOrIRI"
+              "node": "this:HasBodyShape"
+            },
+            {
+              "path": "skos:note",
+              "name": "Note",
+              "description": "A general note, for any purpose. This could e.g. include reasons on which an annotation - such as an mType classification - was based.",
+              "datatype": "xsd:string"
             }
           ]
         }
@@ -144,6 +149,21 @@
             }
           ]
         }
+      ]
+    },
+    {
+      "@id": "this:HasBodyShape",
+      "@type": "sh:NodeShape",
+      "class": "nsg:AnnotationBody",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "property": [
+        {
+          "path": "skos:note",
+          "name": "Note",
+          "description": "A general note, for any purpose. This could e.g. include reasons on which an annotation - such as an mType classification - was based.",
+          "datatype": "xsd:string"
+        }
+
       ]
     },
     {


### PR DESCRIPTION
* to be able to provide more context regarding a specific annotation, a shape to include a skos:note property was added
* the shape was added at the general commons/annotation schema level for notes concerning the whole annotation
* the shape was further added to the hasBody shape for notes concerning only one specifc body of the annotation

Fixes #319 