### PR TITLE
Fixed issues on dash/imagestack schema

### DIFF
--- a/shapes/neurosciencegraph/datashapes/atlas/imagestack/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/imagestack/schema.json
@@ -1,138 +1,132 @@
-{
-  "@context": [
-    "https://incf.github.io/neuroshapes/contexts/schema.json",
-    {
-      "this": "https://neuroshapes.org/dash/imagestack/shapes/"
-    }
-  ],
-  "@id": "https://neuroshapes.org/dash/imagestack",
-  "@type": "nxv:Schema",
-  "import": [
-    "https://neuroshapes.org/commons/transformableobject",
-    "https://neuroshapes.org/commons/quantitativevalue",
-    "https://neuroshapes.org/commons/rotationalmatrix"
-  ],
-  "prov:wasDerivedFrom": "https://github.com/INCF/neuroshapes/blob/v0.3.15/modules/atlas/src/main/resources/schemas/neurosciencegraph/atlas/imagestack/v1.0.0.json",
-  "shapes": [
-    {
-      "@id": "this:ImageStackShape",
-      "@type": "sh:NodeShape",
-      "label": "Image stack",
-      "nodeKind": "sh:BlankNodeOrIRI",
-      "targetClass": "nsg:ImageStack",
-      "and": [
-        {
-          "node": "https://neuroshapes.org/commons/transformableobject/shapes/TransformableObjectShape"
-        },
-        {
-          "property": [
-            {
-              "path": "nsg:imageModality",
-              "name": "Image modality",
-              "description": "Modality of the image stack",
-              "datatype": "xsd:string",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:slicingPlane",
-              "name": "Slicing plane",
-              "description": "Slicing plane of the brain",
-              "in": [
-                "Sagittal",
-                "Para-sagittal",
-                "Coronal",
-                "Horizontal"
-              ],
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:sliceWidth",
-              "name": "Slice width",
-              "description": "Width of the 2D slice",
-              "datatype": "xsd:integer",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:sliceHeight",
-              "name": "Slice height",
-              "description": "Height of the 2D slice",
-              "datatype": "xsd:integer",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:sliceResolution",
-              "name": "Slice resolution",
-              "description": "Resolution of the 2D slice",
-              "node": "this:SliceResolutionShape",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:numberOfSlices",
-              "name": "Number of slices",
-              "description": "Number of slices of the image stack",
-              "datatype": "xsd:integer",
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:sliceInterval",
-              "name": "Slice interval",
-              "description": "Slice interval",
-              "node": "this:SliceIntervalShape",
-              "maxCount": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "this:SliceResolutionShape",
-      "@type": "sh:NodeShape",
-      "and": [
-        {
-          "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape"
-        },
-        {
-          "property": [
-            {
-              "path": "nsg:widthResolution",
-              "name": "Width resolution",
-              "description": "Slice resolution in width",
-              "datatype": "xsd:float",
-              "minCount": 1,
-              "maxCount": 1
-            },
-            {
-              "path": "nsg:heightResolution",
-              "name": "Height resolution",
-              "description": "Slice height",
-              "datatype": "xsd:float",
-              "minCount": 1,
-              "maxCount": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@id": "this:SliceIntervalShape",
-      "@type": "sh:NodeShape",
-      "and": [
-        {
-          "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape"
-        },
-        {
-          "property": [
-            {
-              "path": "nsg:sliceIntervalValue",
-              "name": "Slice interval value",
-              "description": "Slice interval value",
-              "datatype": "xsd:float",
-              "minCount": 1,
-              "maxCount": 1
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+  {
+    "@context": [
+      "https://incf.github.io/neuroshapes/contexts/schema.json",
+      {
+        "this": "https://neuroshapes.org/dash/imagestack/shapes/"
+      }
+    ],
+    "@id": "https://neuroshapes.org/dash/imagestack",
+    "@type": "nxv:Schema",
+    "import": [
+      "https://neuroshapes.org/commons/transformableobject",
+      "https://neuroshapes.org/commons/quantitativevalue"
+    ],
+    "prov:wasDerivedFrom": "https://github.com/INCF/neuroshapes/blob/v0.3.15/modules/atlas/src/main/resources/schemas/neurosciencegraph/atlas/imagestack/v1.0.0.json",
+    "shapes": [
+      {
+        "@id": "this:ImageStackShape",
+        "@type": "sh:NodeShape",
+        "label": "Image stack",
+        "nodeKind": "sh:BlankNodeOrIRI",
+        "targetClass": "nsg:ImageStack",
+        "and": [
+          {
+            "node": "https://neuroshapes.org/commons/transformableobject/shapes/TransformableObjectShape"
+          },
+          {
+            "property": [
+              {
+                "path": "nsg:imageModality",
+                "name": "Image modality",
+                "description": "Modality of the image stack",
+                "datatype": "xsd:string",
+                "maxCount": 1
+              },
+              {
+                "path": "nsg:slicingPlane",
+                "name": "Slicing plane",
+                "description": "Slicing plane of the brain",
+                "in": [
+                  "Sagittal",
+                  "Para-sagittal",
+                  "Coronal",
+                  "Horizontal"
+                ],
+                "maxCount": 1
+              },
+              {
+                "path": "nsg:sliceWidth",
+                "name": "Slice width",
+                "description": "Width of the 2D slice",
+                "datatype": "xsd:integer",
+                "maxCount": 1
+              },
+              {
+                "path": "nsg:sliceHeight",
+                "name": "Slice height",
+                "description": "Height of the 2D slice",
+                "datatype": "xsd:integer",
+                "maxCount": 1
+              },
+              {
+                "path": "nsg:sliceResolution",
+                "name": "Slice resolution",
+                "description": "Resolution of the 2D slice",
+                "node": "this:SliceResolutionShape",
+                "maxCount": 1
+              },
+              {
+                "path": "nsg:numberOfSlices",
+                "name": "Number of slices",
+                "description": "Number of slices of the image stack",
+                "datatype": "xsd:integer",
+                "maxCount": 1
+              },
+              {
+                "path": "nsg:sliceInterval",
+                "name": "Slice interval",
+                "description": "Slice interval",
+                "node": "this:SliceIntervalShape",
+                "maxCount": 1
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "this:SliceResolutionShape",
+        "@type": "sh:NodeShape",
+        "property": [
+          {
+            "path": "nsg:widthResolution",
+            "name": "Width resolution",
+            "description": "Slice resolution in width",
+            "datatype": "xsd:float",
+            "minCount": 1,
+            "maxCount": 1
+          },
+          {
+            "path": "nsg:heightResolution",
+            "name": "Height resolution",
+            "description": "Slice height",
+            "datatype": "xsd:float",
+            "minCount": 1,
+            "maxCount": 1
+          },{
+            "@id":"https://neuroshapes.org/commons/unit/shapes/WithUnitCodeShape"
+          }
+        ]
+      },
+      {
+        "@id": "this:SliceIntervalShape",
+        "@type": "sh:NodeShape",
+        "and": [
+          {
+            "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape"
+          },
+          {
+            "property": [
+              {
+                "path": "schema:value",
+                "name": "Slice interval value",
+                "description": "Slice interval value",
+                "datatype": "xsd:float",
+                "minCount": 1,
+                "maxCount": 1
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/shapes/neurosciencegraph/datashapes/atlas/imagestack/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/imagestack/schema.json
@@ -103,7 +103,18 @@
             "minCount": 1,
             "maxCount": 1
           },{
-            "@id":"https://neuroshapes.org/commons/unit/shapes/WithUnitCodeShape"
+            "path": "schema:unitCode",
+            "name": "Unit",
+            "or": [
+              {
+                "node": "https://neuroshapes.org/commons/labeledontologyentity/shapes/LabeledOntologyEntityShape"
+              },
+              {
+                "datatype": "xsd:string"
+              }
+            ],
+            "minCount": 1,
+            "maxCount": 1
           }
         ]
       },


### PR DESCRIPTION
- Removed unused reference (rotationalmatrix)
- SliceIntervalShape extends now a QuantitativeValueShape
- SliceResolutionShape no longer extends QuantitativeValueShape