### PR TITLE
Add BrainTemplateDataLayer

### DIFF
--- a/shapes/neurosciencegraph/datashapes/atlas/atlasrelease/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/atlasrelease/schema.json
@@ -34,11 +34,11 @@
             },
             {
               "path": "nsg:templateVolume",
-              "class": "nsg:TemplateVolume"
+              "class": "nsg:BrainTemplateDataLayer"
             },
             {
               "path": "nsg:parcellationVolume",
-              "class": "nsg:ParcellationVolume",
+              "class": "nsg:BrainParcellationDataLayer",
               "minCount": 1,
               "maxCount": 1
             },

--- a/shapes/neurosciencegraph/datashapes/atlas/atlasrelease/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/atlasrelease/schema.json
@@ -33,7 +33,7 @@
               "maxCount": 1
             },
             {
-              "path": "nsg:templateVolume",
+              "path": "nsg:brainTemplateDataLayer",
               "class": "nsg:BrainTemplateDataLayer"
             },
             {

--- a/shapes/neurosciencegraph/datashapes/atlas/brainparcellationmesh/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/brainparcellationmesh/schema.json
@@ -34,8 +34,8 @@
             },
             {
               "path": "nsg:brainLocation",
-              "name": "Soma brain location",
-              "description": "Brain Location (brain region, position In Layer, longitudinalAxis) of the reconstructed cell soma.",
+              "name": "Brain location",
+              "description": "Brain Location (brain region, position In Layer, longitudinalAxis) represented by the mesh",
               "node": "https://neuroshapes.org/commons/brainlocation/shapes/BrainLocationShape",
               "minCount": 1,
               "maxCount": 1

--- a/shapes/neurosciencegraph/datashapes/atlas/geneexpressionvolumetricdatalayer/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/geneexpressionvolumetricdatalayer/schema.json
@@ -10,7 +10,6 @@
   "imports": [
     "https://neuroshapes.org/dash/volumetricdatalayer"
   ],
-  "prov:wasDerivedFrom": "https://github.com/INCF/neuroshapes/blob/v0.3.15/modules/atlas/src/main/resources/schemas/neurosciencegraph/atlas/geneexpressionvolumetricdatalayer/v1.0.0.json",
   "shapes": [
     {
       "@id": "this:GeneExpressionVolumetricDataLayerShape",

--- a/shapes/neurosciencegraph/datashapes/atlas/geneexpressionvolumetricdatalayer/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/geneexpressionvolumetricdatalayer/schema.json
@@ -22,7 +22,7 @@
       "nodeKind": "sh:BlankNodeOrIRI",
       "and": [
         {
-          "node": "https://neuroshapes.org/dash/ndraster/shapes/VolumetricDataLayer"
+          "node": "https://neuroshapes.org/dash/volumetricdatalayer/shapes/VolumetricDataLayer"
         },
         {
           "property": [
@@ -30,7 +30,7 @@
               "path": "nsg:gene",
               "name": "Gene",
               "description": "Name of the gene being expressed in this volumetric dataset",
-              "datatype": "xsd:string",
+              "node": "https://neuroshapes.org/commons/labeledontologyentity/shapes/LabeledOntologyEntityShape",
               "minCount": 1,
               "maxCount": 1
             }

--- a/shapes/neurosciencegraph/datashapes/atlas/geneexpressionvolumetricdatalayer/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/geneexpressionvolumetricdatalayer/schema.json
@@ -1,0 +1,43 @@
+{
+  "@context": [
+    "https://incf.github.io/neuroshapes/contexts/schema.json",
+    {
+      "this": "https://neuroshapes.org/dash/geneexpressionvolumetricdatalayer/shapes/"
+    }
+  ],
+  "@id": "https://neuroshapes.org/dash/geneexpressionvolumetricdatalayer",
+  "@type": "nxv:Schema",
+  "imports": [
+    "https://neuroshapes.org/dash/volumetricdatalayer"
+  ],
+  "prov:wasDerivedFrom": "https://github.com/INCF/neuroshapes/blob/v0.3.15/modules/atlas/src/main/resources/schemas/neurosciencegraph/atlas/geneexpressionvolumetricdatalayer/v1.0.0.json",
+  "shapes": [
+    {
+      "@id": "this:GeneExpressionVolumetricDataLayerShape",
+      "@type": "sh:NodeShape",
+      "label": "Data shape definition for volumetric brain data that characterizes gene expression",
+      "targetClass": [
+        "nsg:VolumetricDataLayer",
+        "nsg:GeneExpressionVolumetricDataLayer",
+      ],
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "https://neuroshapes.org/dash/ndraster/shapes/VolumetricDataLayer"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:gene",
+              "name": "Gene",
+              "description": "Name of the gene being expressed in this volumetric dataset",
+              "datatype": "xsd:string",
+              "minCount": 1,
+              "maxCount": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/shapes/neurosciencegraph/datashapes/atlas/volumetricdatalayer/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/volumetricdatalayer/schema.json
@@ -26,7 +26,8 @@
         "nsg:BrainParcellationDataLayer",
         "nsg:MorphologyOrientationDataLayer",
         "nsg:NISSLImageDataLayer",
-        "nsg:TwoPhotonImageDataLayer"
+        "nsg:TwoPhotonImageDataLayer",
+        "nsg:nsg:BrainTemplateDataLayer"
       ],
       "nodeKind": "sh:BlankNodeOrIRI",
       "and": [

--- a/shapes/neurosciencegraph/datashapes/atlas/volumetricdatalayer/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/volumetricdatalayer/schema.json
@@ -27,7 +27,8 @@
         "nsg:MorphologyOrientationDataLayer",
         "nsg:NISSLImageDataLayer",
         "nsg:TwoPhotonImageDataLayer",
-        "nsg:BrainTemplateDataLayer"
+        "nsg:BrainTemplateDataLayer",
+        "nsg:GeneExpressionVolumetricDataLayer"
       ],
       "nodeKind": "sh:BlankNodeOrIRI",
       "and": [

--- a/shapes/neurosciencegraph/datashapes/atlas/volumetricdatalayer/schema.json
+++ b/shapes/neurosciencegraph/datashapes/atlas/volumetricdatalayer/schema.json
@@ -27,7 +27,7 @@
         "nsg:MorphologyOrientationDataLayer",
         "nsg:NISSLImageDataLayer",
         "nsg:TwoPhotonImageDataLayer",
-        "nsg:nsg:BrainTemplateDataLayer"
+        "nsg:BrainTemplateDataLayer"
       ],
       "nodeKind": "sh:BlankNodeOrIRI",
       "and": [


### PR DESCRIPTION
The `BrainTemplateDataLayer` schema inherit from `NdRaster` and `VolumetricDataLayer`. It replaces `TemplateVolume` and will be part of `AtlasRelease`.