### PR TITLE
Created thickness schema

### DIFF
--- a/shapes/neurosciencegraph/commons/typedlabeledontologyterm/schema.json
+++ b/shapes/neurosciencegraph/commons/typedlabeledontologyterm/schema.json
@@ -28,6 +28,21 @@
       ]
     },
     {
+      "@id": "this:StrainOntologyTermShape",
+      "@type": "sh:NodeShape",
+      "label": "The shape of an ontology term representing an animal strain",
+      "nsg:expectedRootClass": {
+        "@id": "nsg:Strain",
+        "label": "Animal strain",
+        "isDefinedBy": "http://bbp.epfl.ch/neurosciencegraph/ontologies/strain"
+      },
+      "and": [
+        {
+          "node": "https://neuroshapes.org/commons/labeledontologyentity/shapes/LabeledOntologyEntityShape"
+        }
+      ]
+    },
+    {
       "@id": "this:ModelSimulationStatusOntologyTermShape",
       "@type": "sh:NodeShape",
       "label": "The shape of an ontology term representing a model simulation status",

--- a/shapes/neurosciencegraph/datashapes/core/thickness/schema.json
+++ b/shapes/neurosciencegraph/datashapes/core/thickness/schema.json
@@ -1,0 +1,68 @@
+{
+  "@context": [
+    "https://incf.github.io/neuroshapes/contexts/schema.json",
+    {
+      "this": "https://neuroshapes.org/dash/thickness/shapes/"
+    }
+  ],
+  "@id": "https://neuroshapes.org/dash/thickness",
+  "@type": "nxv:Schema",
+  "imports": [
+    "https://neuroshapes.org/commons/entity",
+    "https://neuroshapes.org/commons/quantitativevalue",
+    "https://neuroshapes.org/commons/brainlocation"
+  ],
+  "shapes": [
+    {
+      "@id": "this:ThicknessShape",
+      "@type": "sh:NodeShape",
+      "label": "Thickness shape definition",
+      "targetClass": [
+        "nsg:Thickness",
+        "nsg:LayerThickness"
+      ],
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "and": [
+        {
+          "node": "https://neuroshapes.org/commons/entity/shapes/EntityShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:brainLocation",
+              "name": "Brain location",
+              "description": "Brain location information of the thickness (e.g. specific cortical layer).",
+              "node": "https://neuroshapes.org/commons/brainlocation/shapes/BrainLocationShape"
+            },
+            {
+              "path": "nsg:thickness",
+              "name": "Thickness",
+              "description": "Thickness of a neuroscience object such as a brain region layer.",
+              "node": "this:ThicknessQuantitativeValueShape",
+              "minCount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@id": "this:ThicknessQuantitativeValueShape",
+      "@type": "sh:NodeShape",
+      "and": [
+        {
+          "node": "https://neuroshapes.org/commons/quantitativevalue/shapes/QuantitativeValueShape"
+        },
+        {
+          "property": [
+            {
+              "path": "nsg:statistic",
+              "name": "Statistic",
+              "description": "Statistic of the thickness (e.g. mean).",
+              "datatype": "xsd:string"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* created thickness schema by extending entity schema
* this schema can be used for e.g. layer thickness data
* added a StrainOntologyTermShape to the typeedlabeledontologytermshape schema

Fixes #342 