### PR TITLE
Added property shapes to software agent schema

### DIFF
--- a/shapes/neurosciencegraph/datashapes/core/softwareagent/schema.json
+++ b/shapes/neurosciencegraph/datashapes/core/softwareagent/schema.json
@@ -22,8 +22,50 @@
           "datatype": "xsd:string"
         },
         {
+          "path": "schema:description",
+          "name": "Software description",
+          "datatype": "xsd:string"
+        },
+        {
+          "path": "nsg:configuration",
+          "name": "Software configuration",
+          "description": "The configuration used with the software. This can be an IRI or the actual configuration in JSON."
+        },
+        {
+          "path": "nsg:softwareSourceCode",
+          "name": "Software source code",
+          "description": "The software source code.",
+          "class": "schema:SoftwareSourceCode",
+          "node": "this:SoftwareSourceCodeShape"
+        }
+      ]
+    },
+    {
+      "@id": "this:SoftwareSourceCodeShape",
+      "@type": "sh:NodeShape",
+      "property": [
+        {
+          "path": "schema:codeRepository",
+          "name": "Code repository",
+          "description": "Link to the repository where the un-compiled, human readable code and related code is located (SVN, github, CodePlex).",
+          "nodeKind": "sh:IRI"
+        },
+        {
+          "path": "schema:programmingLanguage",
+          "name": "Programming language",
+          "description": "The computer programming language.",
+          "datatype": "xsd:string"
+        },
+        {
+          "path": "schema:runtimePlatform",
+          "name": "Runtime platform",
+          "description": "Runtime platform or script interpreter dependencies (Example - Java v1, Python2.3, .Net Framework 3.0).",
+          "datatype": "xsd:string"
+        },
+        {
           "path": "schema:version",
           "name": "Software version",
+          "description": "The version of the CreativeWork embodied by a specified resource.",
           "datatype": "xsd:string"
         }
       ]

--- a/shapes/neurosciencegraph/datashapes/morphology/labeledcell/schema.json
+++ b/shapes/neurosciencegraph/datashapes/morphology/labeledcell/schema.json
@@ -74,13 +74,6 @@
               "description": "Indicates if the cell can be reconstructed or not",
               "datatype": "xsd:string",
               "maxCount": 1
-            },
-            {
-              "path": "prov:wasRevisionOf",
-              "name": "Patched cell",
-              "description": "The patched cell this labeled cell is a revision of",
-              "class": "nsg:PatchedCell",
-              "maxCount": 1
             }
           ]
         }


### PR DESCRIPTION
1) Added the following property shapes:

- softwareSourceCode 
   - codeRepository
   - programmingLanguage
   - runtimePlatform
   - version
- configuration
- description

2) Removed class constraint on `wasRevisionOf` property from labeled cell schema