### PR TITLE
Added additional property shapes on commons/minds schema

### DIFF
--- a/shapes/neurosciencegraph/commons/minds/schema.json
+++ b/shapes/neurosciencegraph/commons/minds/schema.json
@@ -73,7 +73,7 @@
               "path": "nsg:atlasRelease",
               "nodeKind": "sh:IRI",
               "maxCount": 1
-            }
+            },
             {
               "path": "nsg:objectOfStudy",
               "name": "Object of Study",

--- a/shapes/neurosciencegraph/commons/minds/schema.json
+++ b/shapes/neurosciencegraph/commons/minds/schema.json
@@ -65,6 +65,16 @@
               "minCount": 1
             },
             {
+              "path": "nsg:isRegisteredIn",
+              "class": "nsg:BrainAtlasSpatialReferenceSystem",
+              "maxCount": 1
+            },
+            {
+              "path": "nsg:atlasRelease",
+              "nodeKind": "sh:IRI",
+              "maxCount": 1
+            }
+            {
               "path": "nsg:objectOfStudy",
               "name": "Object of Study",
               "description": "Object of Study",


### PR DESCRIPTION
It was agreed to add the following two property shapes to the `commons/minds` schema (which is imported by the `morphology/neuronmorphology` schema):

- `nsg:atlasRelease`
- `nsg:isRegisteredIn`

These two property shapes will eventually be captured in a brain-independent spatial location shape.

FYI @jonathanlurie @MFSY 